### PR TITLE
Add skeleton aiming support

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/living/monster/AbstractSkeletonEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/living/monster/AbstractSkeletonEntity.java
@@ -25,12 +25,25 @@
 
 package org.geysermc.connector.entity.living.monster;
 
+import com.github.steveice10.mc.protocol.data.game.entity.metadata.EntityMetadata;
 import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.protocol.bedrock.data.EntityData;
 import org.geysermc.connector.entity.type.EntityType;
+import org.geysermc.connector.network.session.GeyserSession;
 
 public class AbstractSkeletonEntity extends MonsterEntity {
 
     public AbstractSkeletonEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
         super(entityId, geyserId, entityType, position, motion, rotation);
+    }
+
+    @Override
+    public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
+        if (entityMetadata.getId() == 14) {
+            byte xd = (byte) entityMetadata.getValue();
+            // A bit of a loophole so the hands get raised - set the target ID to its own ID
+            metadata.put(EntityData.TARGET_EID, (xd == 4) ? geyserId : 0);
+        }
+        super.updateBedrockMetadata(entityMetadata, session);
     }
 }


### PR DESCRIPTION
Skeletons don't have support of pushing their bows back on Bedrock, but this allows them to hold their arms up